### PR TITLE
Add support for a custom command instead of :colorscheme

### DIFF
--- a/autoload/ctrlp/colorscheme.vim
+++ b/autoload/ctrlp/colorscheme.vim
@@ -75,7 +75,11 @@ endfunction
 "
 function! ctrlp#colorscheme#accept(mode, str)
   call ctrlp#exit()
-  execute 'colorscheme' a:str
+  if exists('g:ctrlp_ext_color_command')
+    execute g:ctrlp_ext_color_command a:str
+  else
+    execute 'colorscheme' a:str
+  endif
 endfunction
 
 


### PR DESCRIPTION
Simple change to support a custom command instead of the base `:colorscheme`, so I can use it with [xolox/vim-colorscheme-switcher](https://github.com/xolox/vim-colorscheme-switcher)'s `:SwitchToColorScheme` to preserve the highlight groups that the default command breaks.